### PR TITLE
sites can choose to use a subset of the three supported languages

### DIFF
--- a/app/views/layouts/_langmenu.rhtml
+++ b/app/views/layouts/_langmenu.rhtml
@@ -2,6 +2,13 @@
 langs = [{:code => :en, :name => "English"},
          {:code => :es, :name => "Español"},
          {:code => :fr, :name => "Français"}]
+
+# if the user doesn't want all three languages, we filter it down to the subset
+# they do want
+if @site.languages != :all
+  langs = langs.select{|x| @site.languages.include?(x[:code])}
+end
+
 lang_links = langs.reject{|x| x[:code] == I18n.locale}.map{|x| link_to(x[:name],:locale=>x[:code])}.join(" | ")
 # when translations are ready, render this.
 %>


### PR DESCRIPTION
sites can choose to use a subset of the three supported languages instead of all 3 or just English

So for example, I have a app/sites/blah_site.rb file with

```
def languages
  [:es, :en]
end
```

in order to have a site with only Spanish and English as options.
